### PR TITLE
added db.Database.MigrateAsync() before the role seeding block.

### DIFF
--- a/RadioSignalsBackEnd/RadioSignalsWeb/Program.cs
+++ b/RadioSignalsBackEnd/RadioSignalsWeb/Program.cs
@@ -109,12 +109,15 @@ var app = builder.Build();
 
 using (var scope = app.Services.CreateScope())
 {
-   var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
-      foreach (var name in Enum.GetNames(typeof(Role))) // "USER", "ADMIN"
-         {
-           if (!await roleManager.RoleExistsAsync(name))
+    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    await db.Database.MigrateAsync();
+
+    var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+    foreach (var name in Enum.GetNames(typeof(Role))) // "USER", "ADMIN"
+    {
+        if (!await roleManager.RoleExistsAsync(name))
             await roleManager.CreateAsync(new IdentityRole(name));
-         }
+    }
 }
 
 // Seed municipalities & settlements from JSON on startup (runs once)


### PR DESCRIPTION
Without it, the backend crashed because EF migrations had never been applied to the freshly created Postgres container, so tables like AspNetRoles didn't exist.